### PR TITLE
Fix potential minor bug in MongoDbEventStore

### DIFF
--- a/d60.Cirqus.MongoDb/Events/MongoDbEventStore.cs
+++ b/d60.Cirqus.MongoDb/Events/MongoDbEventStore.cs
@@ -129,7 +129,7 @@ namespace d60.Cirqus.MongoDb.Events
                 {
                     doc.Remove(property.Name);
 
-                    doc.InsertAt(0, new BsonElement(replacement + property.Name.Substring(1), property.Value));
+                    doc.InsertAt(0, new BsonElement(replacement + property.Name.Substring(prefixToReplace.Length), property.Value));
                 }
 
                 if (property.Value.IsBsonDocument)


### PR DESCRIPTION
While reading through the code I noticed that the replacement of prefix was hard coupled to prefixes of one character even though that invariant is not guarenteed by a precondition check. If one ever wanted to change the prefix to be multi character the substring wouldn't be sufficient.
