### PR TITLE
Keep usage of passed in dictionary readonly

### DIFF
--- a/d60.Cirqus.MongoDb/Views/MongoDbViewManager.cs
+++ b/d60.Cirqus.MongoDb/Views/MongoDbViewManager.cs
@@ -138,7 +138,7 @@ namespace d60.Cirqus.MongoDb.Views
 
                 foreach (var viewId in viewIds)
                 {
-                    var viewInstance = GetOrCreateViewInstance(viewId, cachedViewInstances);
+                    var viewInstance = cachedViewInstances[viewId] = GetOrCreateViewInstance(viewId, cachedViewInstances);
 
                     _dispatcherHelper.DispatchToView(viewContext, e, viewInstance);
                 }
@@ -172,8 +172,6 @@ namespace d60.Cirqus.MongoDb.Views
 
             instanceToReturn = _viewCollection.FindOneById(viewId)
                                ?? _dispatcherHelper.CreateNewInstance(viewId);
-
-            cachedViewInstances[viewId] = instanceToReturn;
 
             return instanceToReturn;
         }


### PR DESCRIPTION
While reading through the Dispatch code in the MondoDbViewManager it wasn't obvious how the new view instances would be cached until I noticed that the cachedViewInstance dictionary was mutated in the GetOrCreateViewInstance method.

I made a minor change moving the mutation of the dictionary into the Dispatch method making it more obvious. One very minor caveat is that the cache will be reassigned when the viewId was already in the cache.

I never liked it when things being passed into a method or function were mutated - but you know how I love immutability - that's why I always had a bit of a C++ const reference obsession :-)
