### PR TITLE
Added commandtypeName to all emitted events

### DIFF
--- a/d60.Cirqus/CommandProcessor.cs
+++ b/d60.Cirqus/CommandProcessor.cs
@@ -158,13 +158,22 @@ namespace d60.Cirqus
             var emittedEvents = unitOfWork.EmittedEvents.ToList();
 
             if (!emittedEvents.Any()) return emittedEvents;
-
+            var commandTypeName = ExtractCommandTypeName(command);
             foreach (var e in emittedEvents)
             {
                 e.Meta.Merge(command.Meta);
+                e.Meta[DomainEvent.MetadataKeys.CommandTypeName] = commandTypeName;
+
             }
 
             return emittedEvents;
+        }
+
+        private static string ExtractCommandTypeName(Command command)
+        {
+            var baseType = command.GetType().BaseType;
+            var baseTypeName = baseType != null ? baseType.FullName : "";
+            return baseTypeName;
         }
 
         internal event Action Disposed = delegate { };

--- a/d60.Cirqus/Events/DomainEvent.cs
+++ b/d60.Cirqus/Events/DomainEvent.cs
@@ -21,6 +21,7 @@ namespace d60.Cirqus.Events
             public const string Type = "type";
             public const string RootVersion = "root_ver";
             public const string EventVersion = "evt_ver";
+            public const string CommandTypeName = "command_type";
         }
 
         protected DomainEvent()


### PR DESCRIPTION
It's attached in the commandprocessor.
This will help debugging and in general give a better insight in which commands caused which events, by looking at the meta data.

I know I've missed it one or two times.