### PR TITLE
fixed my own error that always put the basetype in and instead used the ...

### DIFF
--- a/d60.Cirqus.Tests/Commands/TestCommandProcessing.cs
+++ b/d60.Cirqus.Tests/Commands/TestCommandProcessing.cs
@@ -224,8 +224,10 @@ namespace d60.Cirqus.Tests.Commands
 
             //assert
             var events = _eventStore.Result.ToList();
-            var baseType = ordinaryCommand.GetType().BaseType;
-            var expected = baseType.FullName;
+
+            var expected = "d60.Cirqus.Tests.Commands.TestCommandProcessing+AnotherOrdinaryCommand, d60.Cirqus.Tests";
+
+            Assert.AreEqual(expected,events.First().Meta[DomainEvent.MetadataKeys.CommandTypeName]);
             Assert.That(events.All(e =>
                             e.Meta.ContainsKey(DomainEvent.MetadataKeys.CommandTypeName) &&
                             e.Meta[DomainEvent.MetadataKeys.CommandTypeName] == expected), String.Format("Expected {0} but not all had it", expected));
@@ -246,8 +248,8 @@ namespace d60.Cirqus.Tests.Commands
 
             //assert
             var events = _eventStore.Result.ToList();
-            var baseType = executableCommand.GetType().BaseType;
-            var expected = baseType.FullName;
+
+            var expected = "d60.Cirqus.Tests.Commands.TestCommandProcessing+ExecutableCommandTest, d60.Cirqus.Tests";
             Assert.That(events.All(e => 
                             e.Meta.ContainsKey(DomainEvent.MetadataKeys.CommandTypeName) && 
                             e.Meta[DomainEvent.MetadataKeys.CommandTypeName] == expected)   , String.Format("Expected {0} but not all had it", expected));

--- a/d60.Cirqus/CommandProcessor.cs
+++ b/d60.Cirqus/CommandProcessor.cs
@@ -170,11 +170,10 @@ namespace d60.Cirqus
             return emittedEvents;
         }
 
-        static string ExtractCommandTypeName(Command command)
+         string ExtractCommandTypeName(Command command)
         {
-            var baseType = command.GetType().BaseType;
-            var baseTypeName = baseType != null ? baseType.FullName : "";
-            return baseTypeName;
+
+            return _domainTypeNameMapper.GetName(command.GetType());
         }
 
         internal event Action Disposed = delegate { };


### PR DESCRIPTION
...domaintypenameMapper.

This fixes the stupid bug. 

Idea:
Maybe it could be an option you can enable?
Or even register decorators to the commandprocesser it-self in configuration of the command processer.