### PR TITLE
Wrong compare in ExecuteScalarAsync result in PostgreSqlViewManager

### DIFF
--- a/d60.Cirqus.PostgreSql/Views/PostgreSqlViewManager.cs
+++ b/d60.Cirqus.PostgreSql/Views/PostgreSqlViewManager.cs
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS ""{1}"" (
 
                 var result = await command.ExecuteScalarAsync();
 
-                if (DBNull.Value == result)
+                if (result == null || DBNull.Value == result)
                 {
                     return null;
                 }


### PR DESCRIPTION
Based in completely new scenario and Cirqus creates the tables for you. The position tablas are created without any record. When you insert the first event and it subscribed to a view, this event is not dispatched. This behavior only happens with the first event.

The problem is the ExecuteScalarAsync in PostgreSqlViewManager.GetPositionFromPositionTable is returning null instead of DBNull.Value and null is converted to 0 with Convert.ToInt64(result), and 0 is the assigned global secuence number to the first event, so then ViewManagerEventDispatcher thinks that doesn't have nothing to process.