### PR TITLE
Make sure events are returned in the correct sequence order.

### DIFF
--- a/d60.Cirqus.PostgreSql/Events/PostgreSqlEventStore.cs
+++ b/d60.Cirqus.PostgreSql/Events/PostgreSqlEventStore.cs
@@ -178,7 +178,7 @@ INSERT INTO ""{0}"" (
                     {
                         cmd.Transaction = tx;
 
-                        cmd.CommandText = string.Format(@"SELECT ""data"", ""meta"" FROM ""{0}"" WHERE ""aggId"" = @aggId AND ""seqNo"" >= @firstSeqNo", _tableName);
+                        cmd.CommandText = string.Format(@"SELECT ""data"", ""meta"" FROM ""{0}"" WHERE ""aggId"" = @aggId AND ""seqNo"" >= @firstSeqNo ORDER BY ""seqNo""", _tableName);
                         cmd.Parameters.AddWithValue("aggId", aggregateRootId);
                         cmd.Parameters.AddWithValue("firstSeqNo", firstSeq);
 


### PR DESCRIPTION
This prevents `Expected an event with sequence number N.` exceptions. I used to get these exceptions in about 3-5% of the emitted commands. This seems to fix it.

Here's a more detailed explanation of my issue: [http://stackoverflow.com/questions/36487655/cirqus-expected-an-event-with-sequence-number-0-exception](http://stackoverflow.com/questions/36487655/cirqus-expected-an-event-with-sequence-number-0-exception)