### PR TITLE
Remove default constructor requirement for aggregate roots.

### DIFF
--- a/d60.Cirqus.Tests/Contracts/AggregateRootRepository/Factories/DefaultAggregateRootRepositoryFactory.cs
+++ b/d60.Cirqus.Tests/Contracts/AggregateRootRepository/Factories/DefaultAggregateRootRepositoryFactory.cs
@@ -27,7 +27,7 @@ namespace d60.Cirqus.Tests.Contracts.AggregateRootRepository.Factories
         }
 
         public void SaveEvent<TDomainEvent, TAggregateRoot>(TDomainEvent e)
-            where TAggregateRoot : AggregateRoot, new()
+            where TAggregateRoot : AggregateRoot
             where TDomainEvent : DomainEvent<TAggregateRoot>
         {
             _eventStore.Save(Guid.NewGuid(), new[] { _domainEventSerializer.Serialize(e) });

--- a/d60.Cirqus.Tests/Contracts/AggregateRootRepository/IAggregateRootRepositoryFactory.cs
+++ b/d60.Cirqus.Tests/Contracts/AggregateRootRepository/IAggregateRootRepositoryFactory.cs
@@ -8,7 +8,7 @@ namespace d60.Cirqus.Tests.Contracts.AggregateRootRepository
         IAggregateRootRepository GetRepo();
 
         void SaveEvent<TDomainEvent, TAggregateRoot>(TDomainEvent e)
-            where TAggregateRoot : AggregateRoot, new()
+            where TAggregateRoot : AggregateRoot
             where TDomainEvent : DomainEvent<TAggregateRoot>;
     }
 }

--- a/d60.Cirqus/Aggregates/AggregateRoot.cs
+++ b/d60.Cirqus/Aggregates/AggregateRoot.cs
@@ -178,7 +178,7 @@ namespace d60.Cirqus.Aggregates
         /// <summary>
         /// Creates another aggregate root with the specified <paramref name="aggregateRootId"/>. Will throw an exception if a root already exists with the specified ID.
         /// </summary>
-        protected TAggregateRoot Create<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot, new()
+        protected TAggregateRoot Create<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot
         {
             if (UnitOfWork == null)
             {
@@ -213,7 +213,7 @@ namespace d60.Cirqus.Aggregates
         /// Tries to load another aggregate root with the specified <paramref name="aggregateRootId"/>. Returns null if no root exists with that ID.
         /// Throws an <see cref="InvalidCastException"/> if a root was found, but its type was not compatible with the specified <typeparamref name="TAggregateRoot"/> type.
         /// </summary>
-        protected TAggregateRoot TryLoad<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot, new()
+        protected TAggregateRoot TryLoad<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot
         {
             if (UnitOfWork == null)
             {
@@ -255,7 +255,7 @@ namespace d60.Cirqus.Aggregates
         /// Loads another aggregate root with the specified <paramref name="aggregateRootId"/>. Throws an exception if an aggregate root with that ID could not be found.
         /// Also throws an exception if an aggregate root instance was found, but the type was not compatible with the desired <typeparamref name="TAggregateRoot"/>
         /// </summary>
-        protected TAggregateRoot Load<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot, new()
+        protected TAggregateRoot Load<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot
         {
             if (UnitOfWork == null)
             {

--- a/d60.Cirqus/Commands/Command.cs
+++ b/d60.Cirqus/Commands/Command.cs
@@ -40,7 +40,7 @@ namespace d60.Cirqus.Commands
     /// Command base class that is mapped to one specific aggregate root instance for which the <seealso cref="Execute(TAggregateRoot)"/> method will be invoked
     /// </summary>
     /// <typeparam name="TAggregateRoot">Specifies the type of aggregate root that this command targets</typeparam>
-    public abstract class Command<TAggregateRoot> : ExecutableCommand where TAggregateRoot : AggregateRoot, new()
+    public abstract class Command<TAggregateRoot> : ExecutableCommand where TAggregateRoot : AggregateRoot
     {
         protected Command(string aggregateRootId)
         {

--- a/d60.Cirqus/Commands/CompositeCommand.cs
+++ b/d60.Cirqus/Commands/CompositeCommand.cs
@@ -8,7 +8,7 @@ namespace d60.Cirqus.Commands
     /// <summary>
     /// Composite command that allows for packing up multiple commands and have them executed in one single unit of work
     /// </summary>
-    public class CompositeCommand<TAggregateRoot> : Command<TAggregateRoot> where TAggregateRoot : AggregateRoot, new()
+    public class CompositeCommand<TAggregateRoot> : Command<TAggregateRoot> where TAggregateRoot : AggregateRoot
     {
         public List<Command<TAggregateRoot>> Commands { get; set; }
 
@@ -40,13 +40,13 @@ namespace d60.Cirqus.Commands
     public class CompositeCommand
     {
         public static CompositeCommandBuilder<TAggregateRoot> For<TAggregateRoot>()
-            where TAggregateRoot : AggregateRoot, new()
+            where TAggregateRoot : AggregateRoot
         {
             return new CompositeCommandBuilder<TAggregateRoot>();
         }
     }
 
-    public class CompositeCommandBuilder<TAggregateRoot> where TAggregateRoot : AggregateRoot, new()
+    public class CompositeCommandBuilder<TAggregateRoot> where TAggregateRoot : AggregateRoot
     {
         readonly List<Command<TAggregateRoot>> _commands = new List<Command<TAggregateRoot>>();
 

--- a/d60.Cirqus/Testing/TestUnitOfWork.cs
+++ b/d60.Cirqus/Testing/TestUnitOfWork.cs
@@ -33,7 +33,7 @@ namespace d60.Cirqus.Testing
 
         internal event Action Committed = delegate { };
 
-        public TAggregateRoot Load<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot, new()
+        public TAggregateRoot Load<TAggregateRoot>(string aggregateRootId) where TAggregateRoot : AggregateRoot
         {
             var aggregateRoot = _realUnitOfWork.Get<TAggregateRoot>(aggregateRootId, long.MaxValue, createIfNotExists: true);
 


### PR DESCRIPTION
This is to more cleanly support aggregate roots that are instantiated by a factory (which is already supported).